### PR TITLE
Fix broken Discord link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
     <br>
     <br>
   <p>
-    <a href=" https://discord.gg/Epqjm8u2WK"><img src="https://i.imgur.com/lWD9kdU.png" alt="Discord server" width="250" height="70"></a>
+    <a href="https://discord.gg/Epqjm8u2WK"><img src="https://i.imgur.com/lWD9kdU.png" alt="Discord server" width="250" height="70"></a>
     <a href="https://www.twcenter.net/forums/forumdisplay.php?2296-M2TW-Engine-Overhaul-Project"><img src="https://i.imgur.com/rvo91ZR.png" alt="TWC" width="250" height="70"/></a>
     <a href="https://www.youtube.com/channel/UCMyHomaKeeGR4ZPGrBo9dYw"><img src="https://i.imgur.com/iwypXWd.png" alt="YouTube" width="250" height="70"/></a>
   </p>


### PR DESCRIPTION
The Discord link was linking to the image rather than the Discord invite.