### PR TITLE
Upload EOP build artifact

### DIFF
--- a/.github/workflows/composite-actions/build-eop/action.yml
+++ b/.github/workflows/composite-actions/build-eop/action.yml
@@ -53,3 +53,8 @@ runs:
         ls -l documentationGenerator/EOPDocs/build;
         ls -l documentationGenerator/EOPDocs/build/html;
       shell: bash
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: M2TWEOP-latest-build.zip
+        path: M2TWEOP.zip


### PR DESCRIPTION
Closes: https://github.com/youneuoy/M2TWEOP-library/issues/31

See here: https://github.com/youneuoy/M2TWEOP-library/actions/runs/4234153574

After each build, upload the built `M2TWEOP.zip` as an artifact.

It will be stored for 90 days.

![image](https://user-images.githubusercontent.com/22448079/220390501-5ff0d536-6026-4621-92e9-70487e1ea9c4.png)
