### PR TITLE
Allow users to specify a mod version which is displayed in the top left beneath the EOP version at launch

### DIFF
--- a/M2TWEOP Code/M2TWEOP GUI/dataG.h
+++ b/M2TWEOP Code/M2TWEOP GUI/dataG.h
@@ -45,6 +45,7 @@ public:
 
 			// Customization Options
 			string modTitle = "";
+			string modVersion = "";
 			string buttonColorString = "";
 			string buttonHoverColorString = "";
 

--- a/M2TWEOP Code/M2TWEOP GUI/managerG.cpp
+++ b/M2TWEOP Code/M2TWEOP GUI/managerG.cpp
@@ -160,6 +160,10 @@ namespace managerG
 			{
 				getJson(dataG::data.gameData.modTitle, "modTitle");
 			}
+			if (json.contains("modVersion"))
+			{
+				getJson(dataG::data.gameData.modVersion, "modVersion");
+			}
 			if (json.contains("runButtonColor"))
 			{
 				getJson(dataG::data.gameData.buttonColorString, "runButtonColor");
@@ -247,6 +251,7 @@ namespace managerG
 		setJson("playBackgroundMusic", dataG::data.audio.bkgMusic.isMusicNeeded);
 		setJson("musicVolume", dataG::data.audio.bkgMusic.musicVolume);
 		setJson("modTitle", dataG::data.gameData.modTitle);
+		setJson("modVersion", dataG::data.gameData.modVersion);
 		setJson("runButtonColor", dataG::data.gameData.buttonColorString);
 		setJson("runButtonHoverColor", dataG::data.gameData.buttonHoverColorString);
 		setJson("launcherTheme", dataG::data.modData.themeName);

--- a/M2TWEOP Code/M2TWEOP GUI/modSettingsUI.cpp
+++ b/M2TWEOP Code/M2TWEOP GUI/modSettingsUI.cpp
@@ -161,6 +161,11 @@ namespace modSettingsUI
 				ImGui::Text("Warning: Mod path in %s does not match the current directory.", dataG::data.modData.configName.c_str());
 			}
 		}
+	
+		ImGui::Text("Mod Version");
+		ImGui::InputText("", &dataG::data.gameData.modVersion);
+		if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) { ImGui::SetTooltip("Mod version to display in the top left corner beneath EOP version. Set it in eopData/config/uiCfg.json");}
+
 		ImGui::Checkbox("Use M2TWEOP", &dataG::data.modData.useM2TWEOP);
 		if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) { ImGui::SetTooltip("Enable EOP when launching the mod");}
 
@@ -192,11 +197,6 @@ namespace modSettingsUI
 		{
 			dataG::data.audio.bkgMusic.music->setVolume(dataG::data.audio.bkgMusic.musicVolume);
 		}
-
-		ImGui::NewLine();
-		ImGui::InputText("Mod Version", &dataG::data.gameData.modVersion);
-		if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) { ImGui::SetTooltip("Mod version to display in the top left corner beneath EOP version");}
-		ImGui::NewLine();
 
 		// Get all the TOML files in the eopData/resources/themes folder
 		std::vector<std::string> tomlFiles = helpers::getTomlFilesInFolder();
@@ -289,6 +289,7 @@ namespace modSettingsUI
 		if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) { ImGui::SetTooltip("Path to where you have Freecam installed (e.g  C:\\Users\\stead\\Documents\\Modding Tools\\Med2 Modding Tools\\Freecam)");}
 		ImGui::InputText("", &dataG::data.gameData.freecamFolder);
 		if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) { ImGui::SetTooltip("Path to where you have Freecam installed (e.g  C:\\Users\\stead\\Documents\\Modding Tools\\Med2 Modding Tools\\Freecam)");}
+		ImGui::NewLine();
 	}
 	
 	void drawModSettingsUI(bool* isOpen)

--- a/M2TWEOP Code/M2TWEOP GUI/modSettingsUI.cpp
+++ b/M2TWEOP Code/M2TWEOP GUI/modSettingsUI.cpp
@@ -95,9 +95,6 @@ namespace modSettingsUI
 
 	void drawGeneralSettings()
 	{
-
-		//ImGui::InputText("Config file name", &dataG::data.modData.configName);
-
 		std::vector<std::string> cfgFiles = helpers::getCfgFilesInFolder();
 		std::vector<const char*> items;
 		for (const auto& file : cfgFiles) {
@@ -189,12 +186,16 @@ namespace modSettingsUI
 				dataG::data.audio.bkgMusic.music->play();
 			}
 		}
-		if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) { ImGui::SetTooltip("Enabled music in the EOP Launcher");}
+		if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) { ImGui::SetTooltip("Enable music in the EOP Launcher");}
 
 		if (ImGui::SliderInt("Music volume", &dataG::data.audio.bkgMusic.musicVolume, 0, 100))
 		{
 			dataG::data.audio.bkgMusic.music->setVolume(dataG::data.audio.bkgMusic.musicVolume);
 		}
+
+		ImGui::NewLine();
+		ImGui::InputText("Mod Version", &dataG::data.gameData.modVersion);
+		if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) { ImGui::SetTooltip("Mod version to display in the top left corner beneath EOP version");}
 		ImGui::NewLine();
 
 		// Get all the TOML files in the eopData/resources/themes folder

--- a/M2TWEOP Code/M2TWEOP library/globals.h
+++ b/M2TWEOP Code/M2TWEOP library/globals.h
@@ -21,6 +21,7 @@ public:
 			bool isBlockLaunchWithoutEop = false;
 			bool isDiscordRichPresenceEnabled = true;
 			string launcherTheme = "default";
+			string modVersion = "";
 		}gameCfg;
 		struct modulesS
 		{

--- a/M2TWEOP Code/M2TWEOP library/graphicsEvents.cpp
+++ b/M2TWEOP Code/M2TWEOP library/graphicsEvents.cpp
@@ -2,6 +2,7 @@
 #include "graphicsEvents.h"
 #include "console.h"
 #include "luaPlugin.h"
+#include "globals.h"
 
 struct
 {
@@ -28,7 +29,7 @@ void drawOnEndScene(LPDIRECT3DDEVICE9 pDevice)
 			ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_Always);
 			ImGui::Begin("eopInitTitle", nullptr, transparentF);
 
-			// ImGui::Text("M2TWEOP LUA PLUGIN");
+			ImGui::Text(globals::dataS.gameCfg.modVersion);
 
 			ImGui::End();
 		}

--- a/M2TWEOP Code/M2TWEOP library/graphicsEvents.cpp
+++ b/M2TWEOP Code/M2TWEOP library/graphicsEvents.cpp
@@ -29,7 +29,7 @@ void drawOnEndScene(LPDIRECT3DDEVICE9 pDevice)
 			ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_Always);
 			ImGui::Begin("eopInitTitle", nullptr, transparentF);
 
-			ImGui::Text(globals::dataS.gameCfg.modVersion);
+			ImGui::Text(globals::dataS.gameCfg.modVersion.c_str());
 
 			ImGui::End();
 		}

--- a/M2TWEOP Code/M2TWEOP library/graphicsEvents.cpp
+++ b/M2TWEOP Code/M2TWEOP library/graphicsEvents.cpp
@@ -26,12 +26,12 @@ void drawOnEndScene(LPDIRECT3DDEVICE9 pDevice)
 		{
 			static ImGuiWindowFlags transparentF = ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove;
 
-			ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_Always);
-			ImGui::Begin("eopInitTitle", nullptr, transparentF);
-
-			ImGui::Text(globals::dataS.gameCfg.modVersion.c_str());
-
-			ImGui::End();
+			if ((globals::dataS.gameCfg.modVersion).length() > 0){
+				ImGui::SetNextWindowPos(ImVec2(0, 0), ImGuiCond_Always);
+				ImGui::Begin("eopInitTitle", nullptr, transparentF);
+					ImGui::Text(globals::dataS.gameCfg.modVersion.c_str());
+				ImGui::End();
+			}
 		}
 		else
 		{

--- a/M2TWEOP Code/M2TWEOP library/managerF.cpp
+++ b/M2TWEOP Code/M2TWEOP library/managerF.cpp
@@ -1116,6 +1116,10 @@ void managerF::loadJsonSettings()
 		{
 			getJson(globals::dataS.gameCfg.launcherTheme, "launcherTheme")
 		}
+		if (json.contains("modVersion"))
+		{
+			getJson(globals::dataS.gameCfg.modVersion, "modVersion")
+		}
 	}
 	catch (jsn::json::type_error& e)
 	{

--- a/M2TWEOP DataFiles/eopData/config/uiCfg.json
+++ b/M2TWEOP DataFiles/eopData/config/uiCfg.json
@@ -8,5 +8,6 @@
     "modTitle": "",
     "runButtonColor": "201, 169, 64, 150",
     "runButtonHoverColor": "201, 169, 64, 250",
-    "launcherTheme": "default"
+    "launcherTheme": "default",
+    "modVersion": ""
 }

--- a/buildEOP.ps1
+++ b/buildEOP.ps1
@@ -25,9 +25,9 @@ new-item ./logs -itemtype directory -erroraction 'silentlycontinue'
 # 1) Build M2TWEOP-library
 Write-Host "`n`n======== 1) Build M2TWEOP-library ========`n" -ForegroundColor Magenta
 
-msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP library" /fileLogger /fileLoggerParameters:LogFile=logs\library.log /consoleLoggerParameters:ErrorsOnly;ForceConsoleColor -m
-msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP GUI" /fileLogger /fileLoggerParameters:LogFile=logs\gui.log /consoleLoggerParameters:ErrorsOnly;ForceConsoleColor -m
-msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"d3d9" /fileLogger /fileLoggerParameters:LogFile=logs\d3d9.log /consoleLoggerParameters:ErrorsOnly;ForceConsoleColor -m
+msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP library" /fileLogger /fileLoggerParameters:LogFile=logs\library.log /consoleLoggerParameters:ErrorsOnly;ForceConsoleColor /terminalLogger /maxCpuCount
+msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP GUI" /fileLogger /fileLoggerParameters:LogFile=logs\gui.log /consoleLoggerParameters:ErrorsOnly;ForceConsoleColor /terminalLogger /maxCpuCount
+msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"d3d9" /fileLogger /fileLoggerParameters:LogFile=logs\d3d9.log /consoleLoggerParameters:ErrorsOnly;ForceConsoleColor /terminalLogger /maxCpuCount
 
 # 3) Build Documentation
 Write-Host "`n`n======== 3) Build M2TWEOP-Documentation ========`n" -ForegroundColor Magenta

--- a/buildEOP.ps1
+++ b/buildEOP.ps1
@@ -25,9 +25,9 @@ new-item ./logs -itemtype directory -erroraction 'silentlycontinue'
 # 1) Build M2TWEOP-library
 Write-Host "`n`n======== 1) Build M2TWEOP-library ========`n" -ForegroundColor Magenta
 
-msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP library" /fileLogger /fileLoggerParameters:LogFile=logs\library.log /NoWarn:ALL -m
-msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP GUI" /fileLogger /fileLoggerParameters:LogFile=logs\gui.log /NoWarn:ALL -m
-msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"d3d9" /fileLogger /fileLoggerParameters:LogFile=logs\d3d9.log /NoWarn:ALL -m
+msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP library" /fileLogger /fileLoggerParameters:LogFile=logs\library.log /consoleLoggerParameters:ErrorsOnly;ForceConsoleColor -m
+msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP GUI" /fileLogger /fileLoggerParameters:LogFile=logs\gui.log /consoleLoggerParameters:ErrorsOnly;ForceConsoleColor -m
+msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"d3d9" /fileLogger /fileLoggerParameters:LogFile=logs\d3d9.log /consoleLoggerParameters:ErrorsOnly;ForceConsoleColor -m
 
 # 3) Build Documentation
 Write-Host "`n`n======== 3) Build M2TWEOP-Documentation ========`n" -ForegroundColor Magenta

--- a/buildEOP.ps1
+++ b/buildEOP.ps1
@@ -25,9 +25,9 @@ new-item ./logs -itemtype directory -erroraction 'silentlycontinue'
 # 1) Build M2TWEOP-library
 Write-Host "`n`n======== 1) Build M2TWEOP-library ========`n" -ForegroundColor Magenta
 
-msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP library" /fileLogger /fileLoggerParameters:LogFile=logs\library.log /consoleLoggerParameters:ErrorsOnly;ForceConsoleColor /terminalLogger /maxCpuCount
-msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP GUI" /fileLogger /fileLoggerParameters:LogFile=logs\gui.log /consoleLoggerParameters:ErrorsOnly;ForceConsoleColor /terminalLogger /maxCpuCount
-msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"d3d9" /fileLogger /fileLoggerParameters:LogFile=logs\d3d9.log /consoleLoggerParameters:ErrorsOnly;ForceConsoleColor /terminalLogger /maxCpuCount
+msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP library" /fileLogger /fileLoggerParameters:LogFile=logs\library.log /NoWarn:ALL -m
+msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP GUI" /fileLogger /fileLoggerParameters:LogFile=logs\gui.log /NoWarn:ALL -m
+msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"d3d9" /fileLogger /fileLoggerParameters:LogFile=logs\d3d9.log /NoWarn:ALL -m
 
 # 3) Build Documentation
 Write-Host "`n`n======== 3) Build M2TWEOP-Documentation ========`n" -ForegroundColor Magenta

--- a/buildEOP.ps1
+++ b/buildEOP.ps1
@@ -24,10 +24,17 @@ new-item ./logs -itemtype directory -erroraction 'silentlycontinue'
 
 # 1) Build M2TWEOP-library
 Write-Host "`n`n======== 1) Build M2TWEOP-library ========`n" -ForegroundColor Magenta
+msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP library" /fileLogger /fileLoggerParameters:LogFile=logs\library.log /NoWarn:ALL /Verbosity:Minimal /p:WarningLevel=0 /p:RunCodeAnalysis=false -m
+if ($LASTEXITCODE -ne 0) { Write-Host "`n`n!!! Failure detected. Stopping the build process. !!!" -ForegroundColor DarkRed ; exit $LASTEXITCODE }
+# Build M2TWEOP GUI
+msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP GUI" /fileLogger /fileLoggerParameters:LogFile=logs\gui.log /NoWarn:ALL /Verbosity:Minimal  -m
+if ($LASTEXITCODE -ne 0) { Write-Host "`n`n!!! Failure detected. Stopping the build process. !!!" -ForegroundColor DarkRed ; exit $LASTEXITCODE }
 
-msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP library" /fileLogger /fileLoggerParameters:LogFile=logs\library.log /NoWarn:ALL -m
-msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP GUI" /fileLogger /fileLoggerParameters:LogFile=logs\gui.log /NoWarn:ALL -m
-msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"d3d9" /fileLogger /fileLoggerParameters:LogFile=logs\d3d9.log /NoWarn:ALL -m
+# Build d3d9
+msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"d3d9" /fileLogger /fileLoggerParameters:LogFile=logs\d3d9.log /NoWarn:ALL /Verbosity:Minimal -m
+if ($LASTEXITCODE -ne 0) { Write-Host "`n`n!!! Failure detected. Stopping the build process. !!!" -ForegroundColor DarkRed ; exit $LASTEXITCODE }
+
+Write-Host "`n`n======== Success! ========`n" -ForegroundColor Green
 
 # 3) Build Documentation
 Write-Host "`n`n======== 3) Build M2TWEOP-Documentation ========`n" -ForegroundColor Magenta
@@ -66,4 +73,4 @@ if ($modFolder) {
 }
 
 # 7) Done
-Write-Host "`n`n======== Success! EOP Built Successfully! ========`n" -ForegroundColor Magenta
+Write-Host "`n`n======== Success! EOP Built Successfully! ========`n" -ForegroundColor Green

--- a/buildEOPDev_debug.ps1
+++ b/buildEOPDev_debug.ps1
@@ -25,8 +25,13 @@ new-item ./logs -itemtype directory -erroraction 'silentlycontinue'
 Write-Host "`n`n======== 1) Build M2TWEOP-library ========`n" -ForegroundColor Magenta
 
 msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Debug /p:Platform=x86 /t:"M2TWEOP library" /fileLogger /fileLoggerParameters:LogFile=logs\library.log /NoWarn:ALL -m
+if ($LASTEXITCODE -ne 0) { Write-Host "`n`n!!! Failure detected. Stopping the build process. !!!" -ForegroundColor DarkRed ; exit $LASTEXITCODE }
+
 msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Debug /p:Platform=x86 /t:"M2TWEOP GUI" /fileLogger /fileLoggerParameters:LogFile=logs\gui.log /NoWarn:ALL -m
+if ($LASTEXITCODE -ne 0) { Write-Host "`n`n!!! Failure detected. Stopping the build process. !!!" -ForegroundColor DarkRed ; exit $LASTEXITCODE }
+
 msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Debug /p:Platform=x86 /t:"d3d9" /fileLogger /fileLoggerParameters:LogFile=logs\d3d9.log /NoWarn:ALL -m
+if ($LASTEXITCODE -ne 0) { Write-Host "`n`n!!! Failure detected. Stopping the build process. !!!" -ForegroundColor DarkRed ; exit $LASTEXITCODE }
 
 # 3) Build Documentation
 Write-Host "`n`n======== 3) Build M2TWEOP-Documentation ========`n" -ForegroundColor Magenta

--- a/buildEOPDev_debug.ps1
+++ b/buildEOPDev_debug.ps1
@@ -24,9 +24,9 @@ new-item ./logs -itemtype directory -erroraction 'silentlycontinue'
 # 1) Build M2TWEOP-library
 Write-Host "`n`n======== 1) Build M2TWEOP-library ========`n" -ForegroundColor Magenta
 
-msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Debug /p:Platform=x86 /t:"M2TWEOP library" /fileLogger /fileLoggerParameters:LogFile=logs\library.log /consoleLoggerParameters:ErrorsOnly;ForceConsoleColor /terminalLogger /maxCpuCount:1
-msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Debug /p:Platform=x86 /t:"M2TWEOP GUI" /fileLogger /fileLoggerParameters:LogFile=logs\gui.log /consoleLoggerParameters:ErrorsOnly;ForceConsoleColor /terminalLogger /maxCpuCount:1
-msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Debug /p:Platform=x86 /t:"d3d9" /fileLogger /fileLoggerParameters:LogFile=logs\d3d9.log /consoleLoggerParameters:ErrorsOnly;ForceConsoleColor /terminalLogger /maxCpuCount:1
+msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Debug /p:Platform=x86 /t:"M2TWEOP library" /fileLogger /fileLoggerParameters:LogFile=logs\library.log /NoWarn:ALL -m
+msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Debug /p:Platform=x86 /t:"M2TWEOP GUI" /fileLogger /fileLoggerParameters:LogFile=logs\gui.log /NoWarn:ALL -m
+msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Debug /p:Platform=x86 /t:"d3d9" /fileLogger /fileLoggerParameters:LogFile=logs\d3d9.log /NoWarn:ALL -m
 
 # 3) Build Documentation
 Write-Host "`n`n======== 3) Build M2TWEOP-Documentation ========`n" -ForegroundColor Magenta

--- a/buildEOPDev_debug.ps1
+++ b/buildEOPDev_debug.ps1
@@ -24,9 +24,9 @@ new-item ./logs -itemtype directory -erroraction 'silentlycontinue'
 # 1) Build M2TWEOP-library
 Write-Host "`n`n======== 1) Build M2TWEOP-library ========`n" -ForegroundColor Magenta
 
-msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Debug /p:Platform=x86 /t:"M2TWEOP library" /fileLogger /fileLoggerParameters:LogFile=logs\library.log /NoWarn:ALL -m
-msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Debug /p:Platform=x86 /t:"M2TWEOP GUI" /fileLogger /fileLoggerParameters:LogFile=logs\gui.log /NoWarn:ALL -m
-msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Debug /p:Platform=x86 /t:"d3d9" /fileLogger /fileLoggerParameters:LogFile=logs\d3d9.log /NoWarn:ALL -m
+msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Debug /p:Platform=x86 /t:"M2TWEOP library" /fileLogger /fileLoggerParameters:LogFile=logs\library.log /consoleLoggerParameters:ErrorsOnly;ForceConsoleColor /terminalLogger /maxCpuCount:1
+msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Debug /p:Platform=x86 /t:"M2TWEOP GUI" /fileLogger /fileLoggerParameters:LogFile=logs\gui.log /consoleLoggerParameters:ErrorsOnly;ForceConsoleColor /terminalLogger /maxCpuCount:1
+msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Debug /p:Platform=x86 /t:"d3d9" /fileLogger /fileLoggerParameters:LogFile=logs\d3d9.log /consoleLoggerParameters:ErrorsOnly;ForceConsoleColor /terminalLogger /maxCpuCount:1
 
 # 3) Build Documentation
 Write-Host "`n`n======== 3) Build M2TWEOP-Documentation ========`n" -ForegroundColor Magenta

--- a/buildEOPDev_release.ps1
+++ b/buildEOPDev_release.ps1
@@ -25,8 +25,13 @@ new-item ./logs -itemtype directory -erroraction 'silentlycontinue'
 Write-Host "`n`n======== 1) Build M2TWEOP-library ========`n" -ForegroundColor Magenta
 
 msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP library" /fileLogger /fileLoggerParameters:LogFile=logs\library.log /NoWarn:ALL -m
+if ($LASTEXITCODE -ne 0) { Write-Host "`n`n!!! Failure detected. Stopping the build process. !!!" -ForegroundColor DarkRed ; exit $LASTEXITCODE }
+
 msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP GUI" /fileLogger /fileLoggerParameters:LogFile=logs\gui.log /NoWarn:ALL -m
+if ($LASTEXITCODE -ne 0) { Write-Host "`n`n!!! Failure detected. Stopping the build process. !!!" -ForegroundColor DarkRed ; exit $LASTEXITCODE }
+
 msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"d3d9" /fileLogger /fileLoggerParameters:LogFile=logs\d3d9.log /NoWarn:ALL -m
+if ($LASTEXITCODE -ne 0) { Write-Host "`n`n!!! Failure detected. Stopping the build process. !!!" -ForegroundColor DarkRed ; exit $LASTEXITCODE }
 
 # 3) Build Documentation
 Write-Host "`n`n======== 3) Build M2TWEOP-Documentation ========`n" -ForegroundColor Magenta

--- a/buildEOPDev_release.ps1
+++ b/buildEOPDev_release.ps1
@@ -24,9 +24,9 @@ new-item ./logs -itemtype directory -erroraction 'silentlycontinue'
 # 1) Build M2TWEOP-library
 Write-Host "`n`n======== 1) Build M2TWEOP-library ========`n" -ForegroundColor Magenta
 
-msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP library" /fileLogger /fileLoggerParameters:LogFile=logs\library.log /NoWarn:ALL -m
-msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP GUI" /fileLogger /fileLoggerParameters:LogFile=logs\gui.log /NoWarn:ALL -m
-msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"d3d9" /fileLogger /fileLoggerParameters:LogFile=logs\d3d9.log /NoWarn:ALL -m
+msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP library" /fileLogger /fileLoggerParameters:LogFile=logs\library.log /consoleLoggerParameters:ErrorsOnly;ForceConsoleColor /terminalLogger
+msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP GUI" /fileLogger /fileLoggerParameters:LogFile=logs\gui.log /consoleLoggerParameters:ErrorsOnly;ForceConsoleColor /terminalLogger
+msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"d3d9" /fileLogger /fileLoggerParameters:LogFile=logs\d3d9.log /consoleLoggerParameters:ErrorsOnly;ForceConsoleColor /terminalLogger
 
 # 3) Build Documentation
 Write-Host "`n`n======== 3) Build M2TWEOP-Documentation ========`n" -ForegroundColor Magenta

--- a/buildEOPDev_release.ps1
+++ b/buildEOPDev_release.ps1
@@ -24,9 +24,9 @@ new-item ./logs -itemtype directory -erroraction 'silentlycontinue'
 # 1) Build M2TWEOP-library
 Write-Host "`n`n======== 1) Build M2TWEOP-library ========`n" -ForegroundColor Magenta
 
-msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP library" /fileLogger /fileLoggerParameters:LogFile=logs\library.log /consoleLoggerParameters:ErrorsOnly;ForceConsoleColor /terminalLogger
-msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP GUI" /fileLogger /fileLoggerParameters:LogFile=logs\gui.log /consoleLoggerParameters:ErrorsOnly;ForceConsoleColor /terminalLogger
-msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"d3d9" /fileLogger /fileLoggerParameters:LogFile=logs\d3d9.log /consoleLoggerParameters:ErrorsOnly;ForceConsoleColor /terminalLogger
+msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP library" /fileLogger /fileLoggerParameters:LogFile=logs\library.log /NoWarn:ALL -m
+msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"M2TWEOP GUI" /fileLogger /fileLoggerParameters:LogFile=logs\gui.log /NoWarn:ALL -m
+msbuild  "M2TWEOP Code\M2TWEOP library.sln"/p:Configuration=Release /p:Platform=x86 /t:"d3d9" /fileLogger /fileLoggerParameters:LogFile=logs\d3d9.log /NoWarn:ALL -m
 
 # 3) Build Documentation
 Write-Host "`n`n======== 3) Build M2TWEOP-Documentation ========`n" -ForegroundColor Magenta

--- a/documentationGenerator/generateDocs.ps1
+++ b/documentationGenerator/generateDocs.ps1
@@ -27,4 +27,4 @@ Write-Host "`n`n======== 3.4) Build documentation files  ========`n" -Foreground
 Copy-Item -Path "generatedLuaDocs/*" -Destination "EOPDocs/source/_static/LuaLib" -recurse
 Start-Process -FilePath ".\EOPDocs\WPy32-3890\scripts\cmdEOPDOCS.bat" -Wait -NoNewWindow
 
-Write-Host "`n`n======== 3.5) Success! Documentation built successfully.  ========`n" -ForegroundColor Magenta
+Write-Host "`n`n======== 3.5) Success! Documentation built successfully.  ========`n" -ForegroundColor Green

--- a/documentationGenerator/releaseInfo/releaseDescription.md
+++ b/documentationGenerator/releaseInfo/releaseDescription.md
@@ -10,6 +10,7 @@
 - Added [Freecam](https://www.moddb.com/mods/freecam-medieval-2) integration - *Medik*
   - Specify the path to your Freecam installation and enable the integration to automatically launch and close Freecam whenever you play the game
 - Updated [DXVK](https://github.com/doitsujin/dxvk/releases/tag/v2.4) to v2.4 - *Medik*
+- Allow users to specify a mod version which is displayed in the top left beneath the EOP version at launch - *Medik*
 
 ### **Library**
 - Reduced amount of EOP "branding" displayed on startup - *Medik*


### PR DESCRIPTION
- Allow users to specify a mod version which is displayed in the top left beneath the EOP version at launch
- Build now fails straight away if an error is encountered